### PR TITLE
Allow symfony/console to send events to the surrounding Silex.

### DIFF
--- a/Knp/Provider/ConsoleServiceProvider.php
+++ b/Knp/Provider/ConsoleServiceProvider.php
@@ -20,6 +20,7 @@ class ConsoleServiceProvider implements ServiceProviderInterface
                 $app['console.name'],
                 $app['console.version']
             );
+            $application->setDispatcher($app['dispatcher']);
 
             $app['dispatcher']->dispatch(ConsoleEvents::INIT, new ConsoleEvent($application));
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php":              ">=5.3.2",
-        "symfony/console":   "~2.1"
+        "symfony/console":   "~2.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
We can close the circle here and allow the console application to dispatch events.
