### PR TITLE
Fixed bug: boot the Application when run has executed

### DIFF
--- a/Knp/Console/Application.php
+++ b/Knp/Console/Application.php
@@ -4,6 +4,8 @@ namespace Knp\Console;
 
 use Symfony\Component\Console\Application as BaseApplication;
 use Silex\Application as SilexApplication;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends BaseApplication
 {
@@ -17,8 +19,6 @@ class Application extends BaseApplication
 
         $this->silexApplication = $application;
         $this->projectDirectory = $projectDirectory;
-
-        $application->boot();
     }
 
     public function getSilexApplication()
@@ -29,5 +29,11 @@ class Application extends BaseApplication
     public function getProjectDirectory()
     {
         return $this->projectDirectory;
+    }
+    
+    public function run(InputInterface $input = null, OutputInterface $output = null)
+    {
+        $this->silexApplication->boot();
+        parent::run($input, $output);
     }
 }


### PR DESCRIPTION
The problem is that if you boot the silex application in the constructor
some other providers won't work
