### PR TITLE
Added Silex to the list of dependencies and switched to PSR-4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+phpunit.xml
+composer.lock
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,13 @@
         }
     ],
     "require": {
-        "php":              ">=5.3.2",
-        "symfony/console":   "~2.3|~3.0"
+        "php":              ">=5.5.9",
+        "symfony/console":   "~2.3|~3.0",
+        "silex/silex": "~2.0"
     },
     "autoload": {
-        "psr-0": {
-            "Knp\\": ""
+        "psr-4": {
+            "Knp\\": "Knp/"
         }
     }
 }


### PR DESCRIPTION
The `autoload` section has been switched to PSR-4.

I've added Silex to the list of requirements. 

The version requirement has been kept loose to prevent BC breaks (IMHO the requirement should have been added when 2.x was tagged, but as it hasn't we now have to assume that some people may be using v2.x with Silex 1).
