### PR TITLE
Added tests and travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+
+before_script:
+  - composer self-update
+  - COMPOSER_ROOT_VERSION=dev-master composer install
+
+script:
+  - ./vendor/bin/phpunit

--- a/Knp/Provider/ConsoleServiceProvider.php
+++ b/Knp/Provider/ConsoleServiceProvider.php
@@ -4,18 +4,24 @@ namespace Knp\Provider;
 
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use Silex\Application;
 
 use Knp\Console\Application as ConsoleApplication;
 use Knp\Console\ConsoleEvents;
 use Knp\Console\ConsoleEvent;
 
+/**
+ * Symfony Console service provider for Silex.
+ */
 class ConsoleServiceProvider implements ServiceProviderInterface
 {
     public function register(Container $app)
     {
-        $app['console'] = function() use ($app) {
+        $app['console.name'] = 'Silex console';
+        $app['console.version'] = 'UNKNOWN';
+        // Assume we are in vendor/knplabs/console-service-provider/Knp/Provider
+        $app['console.project_directory'] = __DIR__.'/../../../../..';
 
+        $app['console'] = function () use ($app) {
             $application = new ConsoleApplication(
                 $app,
                 $app['console.project_directory'],
@@ -27,9 +33,5 @@ class ConsoleServiceProvider implements ServiceProviderInterface
 
             return $application;
         };
-    }
-
-    public function boot(Application $app)
-    {
     }
 }

--- a/Tests/Provider/ConsoleServiceProviderTest.php
+++ b/Tests/Provider/ConsoleServiceProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Provider;
+
+use Knp\Console\Application as ConsoleApplication;
+use Knp\Provider\ConsoleServiceProvider;
+use Knp\Tests\Provider\Fixtures\TestCommand;
+use Silex\Application;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+
+class ConsoleServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultConfiguration()
+    {
+        $app = new Application();
+        $app->register(new ConsoleServiceProvider());
+
+        $console = $app['console'];
+        $console->setAutoExit(false);
+        $console->add(new TestCommand());
+
+        $this->assertInstanceOf(ConsoleApplication::class, $console);
+
+        $tester = new ApplicationTester($console);
+        $tester->run(['command' => 'test:test']);
+
+        $this->assertContains('Test command', $tester->getDisplay());
+    }
+
+    public function testApplicationParametersAreInjected()
+    {
+        $app = new Application();
+        $app->register(new ConsoleServiceProvider(), [
+            'console.name' => 'Test application',
+            'console.version' => '1.42',
+            'console.project_directory' => __DIR__,
+        ]);
+        /** @var ConsoleApplication $console */
+        $console = $app['console'];
+
+        $this->assertSame('Test application', $console->getName());
+        $this->assertSame('1.42', $console->getVersion());
+        $this->assertSame(__DIR__, $console->getProjectDirectory());
+    }
+}

--- a/Tests/Provider/Fixtures/TestCommand.php
+++ b/Tests/Provider/Fixtures/TestCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Knp\Tests\Provider\Fixtures;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+        $this->setName('test:test')
+            ->setDescription('Test command.');
+    }
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->write('Test command');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,17 @@
         "symfony/console":   "~2.3|~3.0",
         "silex/silex": "~2.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8|~5.4"
+    },
     "autoload": {
         "psr-4": {
             "Knp\\": "Knp/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Knp\\Tests\\": "Tests/"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="KnpLabs Silex Console Provider Test Suite">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./Knp</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
I added PHPUnit to require-dev, a Travis config file and a couple of tests for the service provider.

ATM, the PR includes the changes from #29 as the tests can't run if Silex is not installed by Composer. It should get cleaner once #29 gets merged.

I also cleaned up the provider a bit (removed an unsused method, and gave default values to the parameters as it's generally better to do this).