### PR TITLE
Allow Silex applications to listen to console events

### DIFF
--- a/Knp/Provider/ConsoleServiceProvider.php
+++ b/Knp/Provider/ConsoleServiceProvider.php
@@ -22,16 +22,17 @@ class ConsoleServiceProvider implements ServiceProviderInterface
         $app['console.project_directory'] = __DIR__.'/../../../../..';
 
         $app['console'] = function () use ($app) {
-            $application = new ConsoleApplication(
+            $console = new ConsoleApplication(
                 $app,
                 $app['console.project_directory'],
                 $app['console.name'],
                 $app['console.version']
             );
+            $console->setDispatcher($app['dispatcher']);
 
-            $app['dispatcher']->dispatch(ConsoleEvents::INIT, new ConsoleEvent($application));
+            $app['dispatcher']->dispatch(ConsoleEvents::INIT, new ConsoleEvent($console));
 
-            return $application;
+            return $console;
         };
     }
 }

--- a/README.md
+++ b/README.md
@@ -106,3 +106,23 @@ $app['dispatcher']->addListener(ConsoleEvents::INIT, function(ConsoleEvent $even
 
 ?>
 ```
+
+## Listen to console events
+
+You can listen to the `Symfony\Component\Console\ConsoleEvents` events
+by adding listeners to Silex:
+
+```php
+<?php
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleEvent;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+
+$app->on(ConsoleEvents::EXCEPTION, function (ConsoleExceptionEvent $event) use ($app) {
+    // Log console errors
+    $app['logger']->error($event->getException()->getMessage());
+});
+
+?>
+```


### PR DESCRIPTION
This injects the Silex dispatcher into the console application so users can listen to console events.

This was proposed in #9 but the original PR is two years old and has conflicts.

There's a new test, so I had to base the PR on #30. The only real commit here is the last one.
