### PR TITLE
Boot Silex before a command is run but not when the console gets loaded

### DIFF
--- a/Knp/Console/Application.php
+++ b/Knp/Console/Application.php
@@ -4,6 +4,8 @@ namespace Knp\Console;
 
 use Silex\Application as SilexApplication;
 use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Silex console application.
@@ -27,6 +29,11 @@ class Application extends BaseApplication
 
         $this->silexApplication = $application;
         $this->projectDirectory = $projectDirectory;
+
+        if ($application['console.boot_in_constructor']) {
+            @trigger_error('Booting the Silex application from the console constructor is deprecated and won\'t be possble in v3 of the console provider.', E_USER_DEPRECATED);
+            $application->boot();
+        }
     }
 
     /**

--- a/Knp/Console/Application.php
+++ b/Knp/Console/Application.php
@@ -27,8 +27,6 @@ class Application extends BaseApplication
 
         $this->silexApplication = $application;
         $this->projectDirectory = $projectDirectory;
-
-        $application->boot();
     }
 
     /**
@@ -49,5 +47,15 @@ class Application extends BaseApplication
     public function getProjectDirectory()
     {
         return $this->projectDirectory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function doRun(InputInterface $input = null, OutputInterface $output = null)
+    {
+        $this->getSilexApplication()->boot();
+
+        return parent::doRun($input, $output);
     }
 }

--- a/Knp/Console/Application.php
+++ b/Knp/Console/Application.php
@@ -52,7 +52,7 @@ class Application extends BaseApplication
     /**
      * {@inheritdoc}
      */
-    public function doRun(InputInterface $input = null, OutputInterface $output = null)
+    public function doRun(InputInterface $input, OutputInterface $output)
     {
         $this->getSilexApplication()->boot();
 

--- a/Knp/Provider/ConsoleServiceProvider.php
+++ b/Knp/Provider/ConsoleServiceProvider.php
@@ -30,6 +30,9 @@ class ConsoleServiceProvider implements ServiceProviderInterface
         $app['console.class'] = ConsoleApplication::class;
         $app['console.command.ids'] = [];
 
+        // Maintain BC with projects that depend on the old behavior (application gets booted from console constructor)
+        $app['console.boot_in_constructor'] = false;
+
         $app['console'] = function () use ($app) {
             /** @var ConsoleApplication $console */
             $console = new $app['console.class'](

--- a/Tests/Provider/ConsoleServiceProviderTest.php
+++ b/Tests/Provider/ConsoleServiceProviderTest.php
@@ -113,7 +113,6 @@ class ConsoleServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($console->has('test:test'));
     }
 
-
     public function testDebugTwigCommand()
     {
         if (!class_exists(DebugCommand::class)) {
@@ -180,5 +179,18 @@ class ConsoleServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $output = $tester->getDisplay();
         $this->assertSame('Booted', $output, 'The Silex application must boot before console commands are executed');
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testBootingSilexFromApplicationConstructor()
+    {
+        $app = new TestBootApplication();
+        $app->register(new ConsoleServiceProvider());
+        $app['console.boot_in_constructor'] = true;
+
+        $console = $app['console'];
+        $this->assertTrue($app->isBooted());
     }
 }

--- a/Tests/Provider/Fixtures/TestBootApplication.php
+++ b/Tests/Provider/Fixtures/TestBootApplication.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Knp\Tests\Provider\Fixtures;
+
+use Silex\Application;
+
+/**
+ * Silex application that lets us check boot status.
+ */
+class TestBootApplication extends Application
+{
+    public function isBooted()
+    {
+        return $this->booted;
+    }
+}

--- a/Tests/Provider/Fixtures/TestBootCommand.php
+++ b/Tests/Provider/Fixtures/TestBootCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Knp\Tests\Provider\Fixtures;
+
+use Knp\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestBootCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+        $this->setName('test:boot')
+            ->setDescription('Test boot command.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var TestBootApplication $silex */
+        $silex = $this->getSilexApplication();
+
+        $output->write($silex->isBooted() ? 'Booted' : 'Not booted');
+    }
+}


### PR DESCRIPTION
I moved the `Silex\Application::boot()` call from the constructor of the console Application class to its `doRun()` method.

That means Silex will boot right before a command is run, and not when the console service is loaded. This will fix #15.

This PR contains tests, so it's based on #30 again. The only real commit is the last one.
