### PR TITLE
Deprecate ConsoleEvents::INIT

### DIFF
--- a/Knp/Provider/ConsoleServiceProvider.php
+++ b/Knp/Provider/ConsoleServiceProvider.php
@@ -34,7 +34,11 @@ class ConsoleServiceProvider implements ServiceProviderInterface
             );
             $console->setDispatcher($app['dispatcher']);
 
-            $app['dispatcher']->dispatch(ConsoleEvents::INIT, new ConsoleEvent($console));
+            if ($app['dispatcher']->hasListeners(ConsoleEvents::INIT)) {
+                @trigger_error('Listening to the Knp\Console\ConsoleEvents::INIT event is deprecated and will be removed in v3 of the service provider. You should extend the console service instead.', E_USER_DEPRECATED);
+
+                $app['dispatcher']->dispatch(ConsoleEvents::INIT, new ConsoleEvent($console));
+            }
 
             return $console;
         };

--- a/README.md
+++ b/README.md
@@ -82,16 +82,42 @@ $application->run();
 ?>
 ```
 
-### Use the Event Dispatcher
+### Extend the `console` service
 
-This way is intended for use by provider developers and exposes an unobstrusive way to register commands in 3 simple steps:
+This way is intended for use by provider developers and exposes an unobstrusive way to register commands.
 
-1. Register a listener to the `ConsoleEvents::INIT` event
-2. ???
-3. PROFIT!
+```php
+<?php
 
-Example:
+une Knp\Console\Application;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 
+class UnderpantsProvider implements ServiceProviderInterface
+{
+    public function register(Container $container)
+    {
+        if (isset($container['console'])) {
+            $container->extend('console', function (Application $console) {
+                $console->add(new CollectCommand());
+                $console->add(new QuestionMarkCommand());
+                $console->add(new ProfitCommand());
+
+                return $console;
+            });
+        }
+    }
+}
+?>
+```
+
+### Use the Event Dispatcher (deprecated)
+
+If you used an old version of the console provider and still listen to the
+`Knp\Console\ConsoleEvents::INIT` event to register commands, you should
+modify your code and extend the `console` service instead.
+
+**Before:**
 ```php
 <?php
 
@@ -103,8 +129,20 @@ $app['dispatcher']->addListener(ConsoleEvents::INIT, function(ConsoleEvent $even
     $app = $event->getApplication();
     $app->add(new MyCommand());            
 });
+```
 
-?>
+**After:**
+```php
+<?php
+
+use My\Command\MyCommand;
+une Knp\Console\Application;
+
+$app->extend('console', function (Application $console) {
+    $console->add(new MyCommand());
+
+    return $console;
+});
 ```
 
 ## Listen to console events
@@ -123,6 +161,4 @@ $app->on(ConsoleEvents::EXCEPTION, function (ConsoleExceptionEvent $event) use (
     // Log console errors
     $app['logger']->error($event->getException()->getMessage());
 });
-
-?>
 ```

--- a/Tests/Provider/ConsoleServiceProviderTest.php
+++ b/Tests/Provider/ConsoleServiceProviderTest.php
@@ -63,4 +63,23 @@ class ConsoleServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($listenerCalled);
     }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Listening to the Knp\Console\ConsoleEvents::INIT event is deprecated %s
+     */
+    public function testKnpConsoleInitEventIsDispatched()
+    {
+        $app = new Application();
+        $app->register(new ConsoleServiceProvider());
+
+        $app['dispatcher']->addListener(\Knp\Console\ConsoleEvents::INIT, function (\Knp\Console\ConsoleEvent $event) {
+            $event->getApplication()->add(new TestCommand());
+        });
+
+        /** @var ConsoleApplication $console */
+        $console = $app['console'];
+
+        $this->assertTrue($console->has('test:test'));
+    }
 }


### PR DESCRIPTION
The `INIT` event is unnecessary as Pimple allows users to extend services.

Listening to the `ConsoleEvents::INIT` now throws a deprecation notice, and the documentation has been amended to advise users to extend the `console` service instead.
