### PR TITLE
Added the console.class and console.command.ids parameters

### DIFF
--- a/Knp/Provider/ConsoleServiceProvider.php
+++ b/Knp/Provider/ConsoleServiceProvider.php
@@ -24,15 +24,22 @@ class ConsoleServiceProvider implements ServiceProviderInterface
         $app['console.version'] = 'UNKNOWN';
         // Assume we are in vendor/knplabs/console-service-provider/Knp/Provider
         $app['console.project_directory'] = __DIR__.'/../../../../..';
+        $app['console.class'] = ConsoleApplication::class;
+        $app['console.command.ids'] = [];
 
         $app['console'] = function () use ($app) {
-            $console = new ConsoleApplication(
+            /** @var ConsoleApplication $console */
+            $console = new $app['console.class'](
                 $app,
                 $app['console.project_directory'],
                 $app['console.name'],
                 $app['console.version']
             );
             $console->setDispatcher($app['dispatcher']);
+
+            foreach ($app['console.command.ids'] as $id) {
+                $console->add($app[$id]);
+            }
 
             if ($app['dispatcher']->hasListeners(ConsoleEvents::INIT)) {
                 @trigger_error('Listening to the Knp\Console\ConsoleEvents::INIT event is deprecated and will be removed in v3 of the service provider. You should extend the console service instead.', E_USER_DEPRECATED);

--- a/Tests/Provider/ConsoleServiceProviderTest.php
+++ b/Tests/Provider/ConsoleServiceProviderTest.php
@@ -5,6 +5,7 @@ namespace Tests\Provider;
 use Knp\Console\Application as ConsoleApplication;
 use Knp\Provider\ConsoleServiceProvider;
 use Knp\Tests\Provider\Fixtures\TestCommand;
+use Knp\Tests\Provider\Fixtures\TestConsoleApplication;
 use Silex\Application;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Tester\ApplicationTester;
@@ -42,6 +43,29 @@ class ConsoleServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Test application', $console->getName());
         $this->assertSame('1.42', $console->getVersion());
         $this->assertSame(__DIR__, $console->getProjectDirectory());
+    }
+
+    public function testCanSetCustomApplicationClass()
+    {
+        $app = new Application();
+        $app->register(new ConsoleServiceProvider(), [
+            'console.class' => TestConsoleApplication::class,
+        ]);
+
+        $this->assertInstanceOf(TestConsoleApplication::class, $app['console']);
+    }
+
+    public function testCommandsAsServiceAreRegistered()
+    {
+        $app = new Application();
+        $app['test_command'] = function () {
+            return new TestCommand();
+        };
+        $app->register(new ConsoleServiceProvider(), [
+            'console.command.ids' => ['test_command'],
+        ]);
+
+        $this->assertTrue($app['console']->has('test:test'));
     }
 
     public function testConsoleEventsAreDispatched()

--- a/Tests/Provider/Fixtures/TestConsoleApplication.php
+++ b/Tests/Provider/Fixtures/TestConsoleApplication.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Knp\Tests\Provider\Fixtures;
+
+use Knp\Console\Application;
+
+class TestConsoleApplication extends Application
+{
+}


### PR DESCRIPTION
This adds two new parameters:
- `console.class`: Allows users to use their own console application class
- `console.command.ids`: Ids of commands registered as services that should be automatically added to the console application (I used this name because it's the one used in the Symfony framework bundle).

The `console.command.ids` parameter allows service providers to declare their commands while keeping the project developer in control (e.g: they can change the parameter value if they don't want all the commands to be added to their application):

```php
<?php

use Pimple\Container;
use Pimple\ServiceProviderInterface;

class MyServiceProvider implements ServiceProviderInterface
{
    public function register(Container $app)
    {
        $app['my.command.foo'] = function () {
            return new \My\FooCommand();
        };
        $app['my.command.bar'] = function () {
            return new \My\BarCommand();
        };
        $app['console.command.ids'] = array_merge(
            $app['console.command.ids'], 
            ['my.command.foo', 'my.command.bar']
        );
    }
}
```
In the Silex bootstrap:
```php
<?php
    $app = new \Silex\Application();
    $app->register(new \Knp\Provider\ConsoleServiceProvider());
    $app->register(new \MyServiceProvider());

    // Specify the commands we want to add
    $app['console.command.ids'] = ['my.command.bar'];

    // Or we could add all the available commands except 'my.command.foo'
    $app['console.command.ids'] = array_diff($app['console.command.ids'], ['my.command.foo']);
```