### PR TITLE
Add WebServerBundle support

### DIFF
--- a/Knp/Provider/WebServerServiceProvider.php
+++ b/Knp/Provider/WebServerServiceProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Knp\Provider;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
+use Symfony\Bundle\WebServerBundle\Command\ServerLogCommand;
+use Symfony\Bundle\WebServerBundle\Command\ServerRunCommand;
+use Symfony\Bundle\WebServerBundle\Command\ServerStartCommand;
+use Symfony\Bundle\WebServerBundle\Command\ServerStatusCommand;
+use Symfony\Bundle\WebServerBundle\Command\ServerStopCommand;
+
+/**
+ * Registers the server:xxx console commands from the WebServerBundle.
+ */
+class WebServerServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * Registers the web server console commands.
+     *
+     * @param Container $container
+     */
+    public function register(Container $container)
+    {
+        if (!isset($container['console'])) {
+            throw new \LogicException('You must register the ConsoleServiceProvider to use the WebServerServiceProvider.');
+        }
+
+        $container['web_server.document_root'] = null;
+        $container['web_server.environment'] = 'dev';
+
+        $commands = [
+            'web_server.command.server_run',
+            'web_server.command.server_start',
+            'web_server.command.server_stop',
+            'web_server.command.server_status',
+        ];
+
+        $container['web_server.command.server_run'] = function (Container $container) {
+            if (null === $docRoot = $container['web_server.document_root']) {
+                throw new \LogicException('You must set the web_server.document_root parameter to use the development web server.');
+            }
+
+            return new ServerRunCommand($docRoot, $container['web_server.environment']);
+        };
+
+        $container['web_server.command.server_start'] = function (Container $container) {
+            if (null === $docRoot = $container['web_server.document_root']) {
+                throw new \LogicException('You must set the web_server.document_root parameter to use the development web server.');
+            }
+
+            return new ServerStartCommand($docRoot, $container['web_server.environment']);
+        };
+
+        $container['web_server.command.server_stop'] = function () {
+            return new ServerStopCommand();
+        };
+
+        $container['web_server.command.server_status'] = function () {
+            return new ServerStatusCommand();
+        };
+
+        if (class_exists(ConsoleFormatter::class)) {
+            $container['web_server.command.server_log'] = function () {
+                return new ServerLogCommand();
+            };
+            $commands[] = 'web_server.command.server_log';
+        }
+
+        $container['console.command.ids'] = array_merge($container['console.command.ids'], $commands);
+    }
+}

--- a/Tests/Provider/WebServerServiceProviderTest.php
+++ b/Tests/Provider/WebServerServiceProviderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Knp\Tests\Provider;
+
+use Knp\Provider\ConsoleServiceProvider;
+use Knp\Provider\WebServerServiceProvider;
+use Silex\Application;
+
+class WebServerServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCommandsAreRegistered()
+    {
+        $app = new Application();
+        $app->register(new ConsoleServiceProvider());
+        $app->register(new WebServerServiceProvider(), [
+            'web_server.document_root' => __DIR__,
+        ]);
+        /** @var \Knp\Console\Application $console */
+        $console = $app['console'];
+
+        $this->assertTrue($console->has('server:run'));
+        $this->assertTrue($console->has('server:start'));
+        $this->assertTrue($console->has('server:stop'));
+        $this->assertTrue($console->has('server:status'));
+        $this->assertTrue($console->has('server:log'));
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage You must register the ConsoleServiceProvider to use the WebServerServiceProvider.
+     */
+    public function testRegistrationFailsIfNoConsoleProvider()
+    {
+        $app = new Application();
+        $app->register(new WebServerServiceProvider(), [
+            'web_server.document_root' => __DIR__,
+        ]);
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage You must set the web_server.document_root parameter to use the development web server.
+     */
+    public function testCannotLoadRunCommandIfNoDocumentRootSet()
+    {
+        $app = new Application();
+        $app->register(new ConsoleServiceProvider());
+        $app->register(new WebServerServiceProvider());
+
+        echo $app['web_server.command.server_run'];
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage You must set the web_server.document_root parameter to use the development web server.
+     */
+    public function testCannotLoadStartCommandIfNoDocumentRootSet()
+    {
+        $app = new Application();
+        $app->register(new ConsoleServiceProvider());
+        $app->register(new WebServerServiceProvider());
+
+        echo $app['web_server.command.server_start'];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
     "require-dev": {
         "symfony/phpunit-bridge": "^3.2",
         "twig/twig": "~1.27|~2.0",
-        "symfony/twig-bridge": "~2.8|^3.0"
+        "symfony/twig-bridge": "~2.8|^3.0",
+        "symfony/web-server-bundle": "^3.3@dev",
+        "symfony/monolog-bridge": "^3.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds a second service provider that registers the `WebServerBundle` commands.

Keeping them in another provider allows users to register it conditionally (i.e: only in a _dev_ environment).
