### PR TITLE
Add the symfony/twig-bridge debug:twig and lint:twig commands

### DIFF
--- a/Knp/Command/Twig/DebugCommand.php
+++ b/Knp/Command/Twig/DebugCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Knp\Command\Twig;
+
+use Pimple\Container;
+use Symfony\Bridge\Twig\Command\DebugCommand as BaseDebugCommand;
+
+/**
+ * Twig DebugCommand that can locate the twig environment in a Pimple container.
+ */
+class DebugCommand extends BaseDebugCommand
+{
+    private $container;
+
+    /**
+     * DebugCommand constructor.
+     *
+     * @param Container $container A Pimple container instance
+     */
+    public function __construct(Container $container)
+    {
+        parent::__construct();
+
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTwigEnvironment()
+    {
+        if (null === $twig = parent::getTwigEnvironment()) {
+            $this->setTwigEnvironment($twig = $this->container['twig']);
+        }
+
+        return $twig;
+    }
+}

--- a/Knp/Command/Twig/LintCommand.php
+++ b/Knp/Command/Twig/LintCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Knp\Command\Twig;
+
+use Pimple\Container;
+use Symfony\Bridge\Twig\Command\LintCommand as BaseLintCommand;
+
+/**
+ * Twig LintCommand that can locate the twig environment in a Pimple container.
+ */
+class LintCommand extends BaseLintCommand
+{
+    private $container;
+
+    /**
+     * DebugCommand constructor.
+     *
+     * @param Container $container A Pimple container instance
+     */
+    public function __construct(Container $container)
+    {
+        parent::__construct();
+
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTwigEnvironment()
+    {
+        if (null === $twig = parent::getTwigEnvironment()) {
+            $this->setTwigEnvironment($twig = $this->container['twig']);
+        }
+
+        return $twig;
+    }
+}

--- a/Knp/Provider/ConsoleServiceProvider.php
+++ b/Knp/Provider/ConsoleServiceProvider.php
@@ -2,11 +2,14 @@
 
 namespace Knp\Provider;
 
+use Knp\Command\Twig\DebugCommand;
+use Knp\Command\Twig\LintCommand;
 use Knp\Console\Application as ConsoleApplication;
 use Knp\Console\ConsoleEvent;
 use Knp\Console\ConsoleEvents;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use Symfony\Bridge\Twig\Command\DebugCommand as TwigBridgeDebugCommand;
 
 /**
  * Symfony Console service provider for Silex.
@@ -49,5 +52,22 @@ class ConsoleServiceProvider implements ServiceProviderInterface
 
             return $console;
         };
+
+        $commands = [];
+
+        if (isset($app['twig']) && class_exists(TwigBridgeDebugCommand::class)) {
+            $app['console.command.twig.debug'] = function (Container $container) {
+                return new DebugCommand($container);
+            };
+
+            $app['console.command.twig.lint'] = function (Container $container) {
+                return new LintCommand($container);
+            };
+
+            $commands[] = 'console.command.twig.debug';
+            $commands[] = 'console.command.twig.lint';
+        }
+
+        $app['console.command.ids'] = $commands;
     }
 }

--- a/Tests/Fixtures/Command/Twig/valid.html.twig
+++ b/Tests/Fixtures/Command/Twig/valid.html.twig
@@ -1,0 +1,2 @@
+
+Hello {{ name }}.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
         "silex/silex": "~2.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.2"
+        "symfony/phpunit-bridge": "^3.2",
+        "twig/twig": "~1.27|~2.0",
+        "symfony/twig-bridge": "~2.8|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This will add `debug:twig` and `lint:twig` if `symfony/twig-bridge` is available and the `TwigServiceProvider` has been registered.