### PR TITLE
Added symfony/yaml commands support

### DIFF
--- a/Knp/Provider/ConsoleServiceProvider.php
+++ b/Knp/Provider/ConsoleServiceProvider.php
@@ -10,6 +10,7 @@ use Knp\Console\ConsoleEvents;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Symfony\Bridge\Twig\Command\DebugCommand as TwigBridgeDebugCommand;
+use Symfony\Component\Yaml\Command\LintCommand as LintYamlCommand;
 
 /**
  * Symfony Console service provider for Silex.
@@ -70,6 +71,13 @@ class ConsoleServiceProvider implements ServiceProviderInterface
 
             $commands['debug:twig'] = 'console.command.twig.debug';
             $commands['lint:twig'] = 'console.command.twig.lint';
+        }
+
+        if (class_exists(LintYamlCommand::class)) {
+            $app['console.command.yaml.lint'] = function () {
+                return new LintYamlCommand();
+            };
+            $commands['lint:yaml'] = 'console.command.yaml.lint';
         }
 
         $app['console.command.ids'] = $commands;

--- a/Tests/Fixtures/Command/Yaml/valid.yml
+++ b/Tests/Fixtures/Command/Yaml/valid.yml
@@ -1,0 +1,4 @@
+
+test:
+    - foo
+    - bar

--- a/Tests/Provider/ConsoleServiceProviderTest.php
+++ b/Tests/Provider/ConsoleServiceProviderTest.php
@@ -14,6 +14,7 @@ use Symfony\Bridge\Twig\Command\DebugCommand;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Yaml\Command\LintCommand as LintYamlCommand;
 
 class ConsoleServiceProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -159,6 +160,29 @@ class ConsoleServiceProviderTest extends \PHPUnit_Framework_TestCase
         $output = $tester->getDisplay();
 
         $this->assertContains('[OK] All 1 Twig files contain valid syntax.', $output);
+    }
+
+    public function testLintYamlCommand()
+    {
+        if (!class_exists(LintYamlCommand::class)) {
+            $this->markTestSkipped('symfony/yaml is not available.');
+        }
+        $app = new Application();
+        $app->register(new ConsoleServiceProvider());
+
+        /** @var ConsoleApplication $console */
+        $console = $app['console'];
+
+        $this->assertTrue($console->has('lint:yaml'));
+
+        $tester = new CommandTester($command = $console->find('lint:yaml'));
+        $tester->execute([
+            'command' => 'lint:yaml',
+            'filename' => __DIR__.'/../Fixtures/Command/Yaml/valid.yml',
+        ]);
+        $output = $tester->getDisplay();
+
+        $this->assertContains('[OK] All 1 YAML files contain valid syntax.', $output);
     }
 
     public function testApplicationBootsBeforeCommand()

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "twig/twig": "~1.27|~2.0",
         "symfony/twig-bridge": "~2.8|^3.0",
         "symfony/web-server-bundle": "^3.3",
-        "symfony/monolog-bridge": "^3.2"
+        "symfony/monolog-bridge": "^3.2",
+        "symfony/yaml": "^2.8|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Registers `lint:yaml` if the `symfony/yaml` component is installed.