### PR TITLE
Fixed an issue that does not work with symfony 3.4

### DIFF
--- a/Knp/Command/Twig/DebugCommand.php
+++ b/Knp/Command/Twig/DebugCommand.php
@@ -10,6 +10,8 @@ use Symfony\Bridge\Twig\Command\DebugCommand as BaseDebugCommand;
  */
 class DebugCommand extends BaseDebugCommand
 {
+    protected static $defaultName = 'debug:twig';
+
     private $container;
 
     /**

--- a/Knp/Command/Twig/LintCommand.php
+++ b/Knp/Command/Twig/LintCommand.php
@@ -10,6 +10,8 @@ use Symfony\Bridge\Twig\Command\LintCommand as BaseLintCommand;
  */
 class LintCommand extends BaseLintCommand
 {
+    protected static $defaultName = 'lint:twig';
+
     private $container;
 
     /**


### PR DESCRIPTION
When running the test with symfony 3.4RC1, the following error occurred.

```
2) Tests\Provider\ConsoleServiceProviderTest::testLintTwigCommand
Symfony\Component\Console\Exception\LogicException: The command defined in "Knp\Command\Twig\DebugCommand" cannot have an empty name.

PHP Fatal error:  Uncaught Symfony\Component\Console\Exception\LogicException: The command defined in "Knp\Command\Twig\LintCommand" cannot have an empty name. in /Users/chihiro_adachi/repos/ConsoleServiceProvider/vendor/symfony/console/Application.php:432
Stack trace:
#0 /Users/chihiro_adachi/repos/ConsoleServiceProvider/Knp/Provider/ConsoleServiceProvider.php(49): Symfony\Component\Console\Application->add(Object(Knp\Command\Twig\LintCommand))
#1 /Users/chihiro_adachi/repos/ConsoleServiceProvider/vendor/pimple/pimple/src/Pimple/Container.php(118): Knp\Provider\ConsoleServiceProvider->Knp\Provider\{closure}(Object(Silex\Application))
#2 /Users/chihiro_adachi/repos/ConsoleServiceProvider/bin/console(28): Pimple\Container->offsetGet('console')
#3 {main}
  thrown in /Users/chihiro_adachi/repos/ConsoleServiceProvider/vendor/symfony/console/Application.php on line 432
```

It seems that the constructor of `Symfony/Console/ Command` has been changed, and the command name can not be acquired. I confirmed that it works by defining `$defaultName`.
