### PR TITLE
Fix TwigBrige 3.4 break : The command defined in "Knp\Command\Twig\DebugCommand" cannot have an   empty name.

### DIFF
--- a/Knp/Command/Twig/DebugCommand.php
+++ b/Knp/Command/Twig/DebugCommand.php
@@ -29,7 +29,8 @@ class DebugCommand extends BaseDebugCommand
      */
     protected function configure()
     {
-        $this->setName(static::$defaultName);
+        $this->setName('debug:twig');
+        parent::configure();
     }
 
     /**

--- a/Knp/Command/Twig/DebugCommand.php
+++ b/Knp/Command/Twig/DebugCommand.php
@@ -23,6 +23,14 @@ class DebugCommand extends BaseDebugCommand
 
         $this->container = $container;
     }
+    
+    /**
+     * Set the default command name
+     */
+    protected function configure()
+    {
+        $this->setName(static::$defaultName);
+    }
 
     /**
      * {@inheritdoc}

--- a/Knp/Command/Twig/LintCommand.php
+++ b/Knp/Command/Twig/LintCommand.php
@@ -23,7 +23,15 @@ class LintCommand extends BaseLintCommand
 
         $this->container = $container;
     }
-
+    
+    /**
+     * Set the default command name
+     */
+    protected function configure()
+    {
+        $this->setName(static::$defaultName);
+    }
+    
     /**
      * {@inheritdoc}
      */

--- a/Knp/Command/Twig/LintCommand.php
+++ b/Knp/Command/Twig/LintCommand.php
@@ -29,7 +29,8 @@ class LintCommand extends BaseLintCommand
      */
     protected function configure()
     {
-        $this->setName(static::$defaultName);
+        $this->setName('lint:twig');
+        parent::configure();
     }
     
     /**


### PR DESCRIPTION
I have this error with TwigBridge 3.4:
```
(1/1) LogicException
    The command defined in "Knp\Command\Twig\DebugCommand" cannot have an empty name.
in Application.php (line 450)
at Application -> add( object( DebugCommand) ) in ConsoleServiceProvider.php (line   49)
at ConsoleServiceProvider -> Knp\Provider\{closure}( object( Application) ) in Container.php (line   118)
at Container -> offsetGet( 'console') in console (line   17)
```

The TwigBridge have changed in Symfony 3.4.

The command contructor parameters have changed. The name must be set by overwriting configure function and use "setName" function.

The default name as be addded info new static variable `static::$defaultName` in version 3.4.

For more compatibility, the name is set with hard writen value.

