### PR TITLE
Fixed compatibility with Symfony 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,26 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+matrix:
+  include:
+    - php: 5.5
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8
+    - php: 5.6
+      env: SYMFONY_VERSION=3.3
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
 
 before_script:
-  - composer self-update
-  - COMPOSER_ROOT_VERSION=dev-master composer install
+  - |
+    if [[ $SYMFONY_VERSION = 2.8 ]]; then
+      composer remove --dev --no-update symfony/web-server-bundle
+      composer require --dev --no-update 'symfony/console:2.8.*' 'symfony/twig-bridge:2.8.*' 'symfony/monolog-bridge:2.8.*' 'symfony/yaml:2.8.*'
+    fi
+    if [[ $SYMFONY_VERSION = 3.3 ]]; then
+      composer require --dev --no-update 'symfony/console:3.3.*' 'symfony/twig-bridge:3.3.*' 'symfony/monolog-bridge:3.3.*' 'symfony/yaml:3.3.*' 'symfony/web-server-bundle:3.3.*'
+    fi
+  - COMPOSER_ROOT_VERSION=dev-master composer update --no-suggest
 
-script:
-  - ./vendor/bin/simple-phpunit
+script: ./vendor/bin/simple-phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ConsoleServiceProvider changelog
 ================================
 
+v2.2.0 (2018-02-05)
+-------------------
+
+- Fixed compatibility with Symfony 3.4 and 4.0 (chihiro-adachi, skalpa)
+
 v2.1.0 (2017-07-18)
 -------------------
 

--- a/Knp/Command/Twig/DebugCommand.php
+++ b/Knp/Command/Twig/DebugCommand.php
@@ -21,7 +21,8 @@ class DebugCommand extends BaseDebugCommand
      */
     public function __construct(Container $container)
     {
-        parent::__construct();
+        // The constructor signature changed in twig-bridge 3.4
+        parent::__construct(isset(parent::$defaultName) ? $container['twig'] : static::$defaultName);
 
         $this->container = $container;
     }

--- a/Knp/Command/Twig/LintCommand.php
+++ b/Knp/Command/Twig/LintCommand.php
@@ -21,7 +21,8 @@ class LintCommand extends BaseLintCommand
      */
     public function __construct(Container $container)
     {
-        parent::__construct();
+        // The constructor signature changed in twig-bridge 3.4
+        parent::__construct(isset(parent::$defaultName) ? $container['twig'] : static::$defaultName);
 
         $this->container = $container;
     }

--- a/Tests/Provider/ConsoleServiceProviderTest.php
+++ b/Tests/Provider/ConsoleServiceProviderTest.php
@@ -165,7 +165,7 @@ class ConsoleServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testLintYamlCommand()
     {
         if (!class_exists(LintYamlCommand::class)) {
-            $this->markTestSkipped('symfony/yaml is not available.');
+            $this->markTestSkipped('symfony/yaml >= 3.2 is not available.');
         }
         $app = new Application();
         $app->register(new ConsoleServiceProvider());

--- a/Tests/Provider/WebServerServiceProviderTest.php
+++ b/Tests/Provider/WebServerServiceProviderTest.php
@@ -5,9 +5,17 @@ namespace Knp\Tests\Provider;
 use Knp\Provider\ConsoleServiceProvider;
 use Knp\Provider\WebServerServiceProvider;
 use Silex\Application;
+use Symfony\Bundle\WebServerBundle\Command\ServerRunCommand;
 
 class WebServerServiceProviderTest extends \PHPUnit_Framework_TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists(ServerRunCommand::class)) {
+            self::markTestSkipped('The web-server-bundle component is not installed');
+        }
+    }
+
     public function testCommandsAreRegistered()
     {
         $app = new Application();

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.1.x-dev"
+            "dev-master": "2.2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
     ],
     "require": {
         "php":              ">=5.5.9",
-        "symfony/console":   "~2.3|~3.0",
+        "symfony/console":   "^2.3|^3.0|^4.0",
         "silex/silex": "~2.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.2",
+        "symfony/phpunit-bridge": "^3.2|^4.0",
         "twig/twig": "~1.27|~2.0",
-        "symfony/twig-bridge": "~2.8|^3.0",
-        "symfony/web-server-bundle": "^3.3",
-        "symfony/monolog-bridge": "^3.2",
-        "symfony/yaml": "^2.8|^3.0"
+        "symfony/twig-bridge": "~2.8|^3.0|^4.0",
+        "symfony/web-server-bundle": "^3.3|^4.0",
+        "symfony/monolog-bridge": "^3.2|^4.0",
+        "symfony/yaml": "^2.8|^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* `composer.json` updated to allow v4 of the components
* Twig commands fixed
* Travis config updated to ensure tests are run with 2.8, 3.3, 3.4 and 4.0
